### PR TITLE
Manifest.json Fixes

### DIFF
--- a/client/assets/manifest.json
+++ b/client/assets/manifest.json
@@ -20,7 +20,7 @@
 		}
 	],
 	"theme_color": "#ffffff",
-  	"start_url": "https://disease-info.herokuapp.com/",
+  	"start_url": "/",
   	"scope": "./views/index.html",
   	"orientation": "portrait",
 	"display": "standalone"


### PR DESCRIPTION
Hey @osioke here are some of the changes -

1. Moved manifest.json to the root directory. That's where it should be, Lighthouse was probably looking for it there instead of followin your link
2. Changed start_url to a relative path. The start url is assumed to be from the host domain, so you shouldn't put the absolute url there
3. Changed scope to "/". This is also based off the host domain, so since only the client folder is being served, that's all that needs to be there

I couldn't test this locally, for some reason it wasn't working when I went to localhost:8080. Let me know if it works.